### PR TITLE
fix: resolve pnpm-related Docker build failures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM node:lts-alpine as build-stage
 WORKDIR /app
 RUN apk add --no-cache python3 make g++
-RUN npm install -g pnpm
+RUN npm install -g pnpm@9
 COPY package.json pnpm-lock.yaml ./
 RUN pnpm install --frozen-lockfile
 COPY . .

--- a/Dockerfile-stage
+++ b/Dockerfile-stage
@@ -2,7 +2,7 @@
 FROM node:lts-alpine as build-stage
 WORKDIR /app
 RUN apk add --no-cache python3 make g++
-RUN npm install -g pnpm
+RUN npm install -g pnpm@9
 COPY package.json pnpm-lock.yaml ./
 RUN pnpm install --frozen-lockfile
 COPY . .

--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
         "tiptap-extensions": "^1.35.2",
         "vue": "^2.7.16",
         "vue-router": "^3.6.5",
-        "vuejs-logger": "^1.10.2"
+        "vuejs-logger": "^1.10.2",
+        "lodash": "^4.17.21",
+        "regenerator-runtime": "^0.13.11"
     },
     "devDependencies": {
         "@vue/cli-plugin-babel": "^4.5.19",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,12 +38,18 @@ importers:
       keycloak-js:
         specifier: ^7.0.1
         version: 7.0.1
+      lodash:
+        specifier: ^4.17.21
+        version: 4.17.21
       moment:
         specifier: ^2.30.1
         version: 2.30.1
       normalize.css:
         specifier: ^8.0.1
         version: 8.0.1
+      regenerator-runtime:
+        specifier: ^0.13.11
+        version: 0.13.11
       tiptap:
         specifier: ^1.32.2
         version: 1.32.2(vue-template-compiler@2.7.16)(vue@2.7.16)


### PR DESCRIPTION
## What changed

Two commits fixing GitHub Actions build failures introduced by the pnpm migration.

## Why

### 1. Declare lodash and regenerator-runtime as explicit dependencies
The build failed with "These dependencies were not found: lodash, regenerator-runtime".
pnpm enforces strict dependency isolation and does not hoist transitive packages,
so both had to be declared explicitly in package.json. Under npm they worked as
phantom (hoisted) dependencies. lodash is imported directly in ComicList.vue,
ComicForm.vue, CommentField.vue, and PredicateList.vue. regenerator-runtime is
injected by the @vue/app Babel preset.

### 2. Pin pnpm to v9 in Dockerfiles
After the first fix, the build failed with ERR_PNPM_IGNORED_BUILDS. pnpm v10
(now installed by `npm install -g pnpm`) introduced a new interactive
`pnpm approve-builds` workflow that requires lockfile-level approval for any
package with build scripts — incompatible with CI. Pinning to pnpm@9 restores
the working onlyBuiltDependencies behavior without further changes.

## Reviewer notes

No logic or feature changes — all fixes are in package.json, pnpm-lock.yaml,
and both Dockerfiles.