### PR TITLE
chore: upgrade sass-loader 12→16

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
         "eslint-plugin-vue": "^10.9.1",
         "prettier": "^3.8.3",
         "sass": "^1.99.0",
-        "sass-loader": "^12.6.0",
+        "sass-loader": "^16.0.8",
         "vue-eslint-parser": "^9.4.3",
         "vue-template-compiler": "^2.7.16"
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,16 +68,16 @@ importers:
         version: 7.28.6(@babel/core@7.15.8)(eslint@9.39.4)
       '@vue/cli-plugin-babel':
         specifier: ^5.0.9
-        version: 5.0.9(@vue/cli-service@5.0.9(@babel/core@7.15.8)(lodash@4.18.1)(prettier@3.8.3)(sass-loader@12.6.0(sass@1.99.0)(webpack@5.106.2(postcss@8.4.35)))(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.4.1))(core-js@3.49.0)(postcss@8.4.35)(vue@2.7.16)
+        version: 5.0.9(@vue/cli-service@5.0.9(@babel/core@7.15.8)(lodash@4.18.1)(prettier@3.8.3)(sass-loader@16.0.8(sass@1.99.0)(webpack@5.106.2(postcss@8.4.35)))(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.4.1))(core-js@3.49.0)(postcss@8.4.35)(vue@2.7.16)
       '@vue/cli-plugin-eslint':
         specifier: ^5.0.9
-        version: 5.0.9(@vue/cli-service@5.0.9(@babel/core@7.15.8)(lodash@4.18.1)(prettier@3.8.3)(sass-loader@12.6.0(sass@1.99.0)(webpack@5.106.2(postcss@8.4.35)))(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.4.1))(eslint@9.39.4)(postcss@8.4.35)
+        version: 5.0.9(@vue/cli-service@5.0.9(@babel/core@7.15.8)(lodash@4.18.1)(prettier@3.8.3)(sass-loader@16.0.8(sass@1.99.0)(webpack@5.106.2(postcss@8.4.35)))(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.4.1))(eslint@9.39.4)(postcss@8.4.35)
       '@vue/cli-plugin-unit-jest':
         specifier: ^5.0.9
-        version: 5.0.9(@vue/cli-service@5.0.9(@babel/core@7.15.8)(lodash@4.18.1)(prettier@3.8.3)(sass-loader@12.6.0(sass@1.99.0)(webpack@5.106.2(postcss@8.4.35)))(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.4.1))(jest@24.9.0)
+        version: 5.0.9(@vue/cli-service@5.0.9(@babel/core@7.15.8)(lodash@4.18.1)(prettier@3.8.3)(sass-loader@16.0.8(sass@1.99.0)(webpack@5.106.2(postcss@8.4.35)))(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.4.1))(jest@24.9.0)
       '@vue/cli-service':
         specifier: ^5.0.9
-        version: 5.0.9(@babel/core@7.15.8)(lodash@4.18.1)(prettier@3.8.3)(sass-loader@12.6.0(sass@1.99.0)(webpack@5.106.2(postcss@8.4.35)))(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.4.1)
+        version: 5.0.9(@babel/core@7.15.8)(lodash@4.18.1)(prettier@3.8.3)(sass-loader@16.0.8(sass@1.99.0)(webpack@5.106.2(postcss@8.4.35)))(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.4.1)
       '@vue/eslint-config-prettier':
         specifier: ^10.2.0
         version: 10.2.0(@types/eslint@9.6.1)(eslint@9.39.4)(prettier@3.8.3)
@@ -109,8 +109,8 @@ importers:
         specifier: ^1.99.0
         version: 1.99.0
       sass-loader:
-        specifier: ^12.6.0
-        version: 12.6.0(sass@1.99.0)(webpack@5.106.2(postcss@8.4.35))
+        specifier: ^16.0.8
+        version: 16.0.8(sass@1.99.0)(webpack@5.106.2(postcss@8.4.35))
       vue-eslint-parser:
         specifier: ^9.4.3
         version: 9.4.3(eslint@9.39.4)
@@ -5244,23 +5244,25 @@ packages:
     deprecated: some dependency vulnerabilities fixed, support for node < 10 dropped, and newer ECMAScript syntax/features added
     hasBin: true
 
-  sass-loader@12.6.0:
-    resolution: {integrity: sha512-oLTaH0YCtX4cfnJZxKSLAyglED0naiYfNG1iXfU5w1LNZ+ukoA5DtyDIN5zmKVZwYNJP4KRc5Y3hkWga+7tYfA==}
-    engines: {node: '>= 12.13.0'}
+  sass-loader@16.0.8:
+    resolution: {integrity: sha512-hcov4ZwZJIGbEuyNr9EmiTmZueyrxSToE6GOzoZnq5JM7ecRO7ttyvilPn+VmRsqiP16+VYZzVnGZj/hzZgKBA==}
+    engines: {node: '>= 18.12.0'}
     peerDependencies:
-      fibers: '>= 3.1.0'
-      node-sass: ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+      '@rspack/core': 0.x || ^1.0.0 || ^2.0.0-0
+      node-sass: ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0
       sass: ^1.3.0
       sass-embedded: '*'
       webpack: ^5.0.0
     peerDependenciesMeta:
-      fibers:
+      '@rspack/core':
         optional: true
       node-sass:
         optional: true
       sass:
         optional: true
       sass-embedded:
+        optional: true
+      webpack:
         optional: true
 
   sass@1.99.0:
@@ -7252,7 +7254,9 @@ snapshots:
       source-map: 0.6.1
       string-length: 2.0.0
     transitivePeerDependencies:
+      - bufferutil
       - supports-color
+      - utf-8-validate
 
   '@jest/schemas@28.1.3':
     dependencies:
@@ -7821,11 +7825,11 @@ snapshots:
 
   '@vue/cli-overlay@5.0.9': {}
 
-  '@vue/cli-plugin-babel@5.0.9(@vue/cli-service@5.0.9(@babel/core@7.15.8)(lodash@4.18.1)(prettier@3.8.3)(sass-loader@12.6.0(sass@1.99.0)(webpack@5.106.2(postcss@8.4.35)))(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.4.1))(core-js@3.49.0)(postcss@8.4.35)(vue@2.7.16)':
+  '@vue/cli-plugin-babel@5.0.9(@vue/cli-service@5.0.9(@babel/core@7.15.8)(lodash@4.18.1)(prettier@3.8.3)(sass-loader@16.0.8(sass@1.99.0)(webpack@5.106.2(postcss@8.4.35)))(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.4.1))(core-js@3.49.0)(postcss@8.4.35)(vue@2.7.16)':
     dependencies:
       '@babel/core': 7.15.8
       '@vue/babel-preset-app': 5.0.9(@babel/core@7.15.8)(core-js@3.49.0)(vue@2.7.16)
-      '@vue/cli-service': 5.0.9(@babel/core@7.15.8)(lodash@4.18.1)(prettier@3.8.3)(sass-loader@12.6.0(sass@1.99.0)(webpack@5.106.2(postcss@8.4.35)))(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.4.1)
+      '@vue/cli-service': 5.0.9(@babel/core@7.15.8)(lodash@4.18.1)(prettier@3.8.3)(sass-loader@16.0.8(sass@1.99.0)(webpack@5.106.2(postcss@8.4.35)))(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.4.1)
       '@vue/cli-shared-utils': 5.0.9
       babel-loader: 8.2.3(@babel/core@7.15.8)(webpack@5.106.2(postcss@8.4.35))
       thread-loader: 3.0.4(webpack@5.106.2(postcss@8.4.35))
@@ -7849,9 +7853,9 @@ snapshots:
       - vue
       - webpack-cli
 
-  '@vue/cli-plugin-eslint@5.0.9(@vue/cli-service@5.0.9(@babel/core@7.15.8)(lodash@4.18.1)(prettier@3.8.3)(sass-loader@12.6.0(sass@1.99.0)(webpack@5.106.2(postcss@8.4.35)))(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.4.1))(eslint@9.39.4)(postcss@8.4.35)':
+  '@vue/cli-plugin-eslint@5.0.9(@vue/cli-service@5.0.9(@babel/core@7.15.8)(lodash@4.18.1)(prettier@3.8.3)(sass-loader@16.0.8(sass@1.99.0)(webpack@5.106.2(postcss@8.4.35)))(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.4.1))(eslint@9.39.4)(postcss@8.4.35)':
     dependencies:
-      '@vue/cli-service': 5.0.9(@babel/core@7.15.8)(lodash@4.18.1)(prettier@3.8.3)(sass-loader@12.6.0(sass@1.99.0)(webpack@5.106.2(postcss@8.4.35)))(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.4.1)
+      '@vue/cli-service': 5.0.9(@babel/core@7.15.8)(lodash@4.18.1)(prettier@3.8.3)(sass-loader@16.0.8(sass@1.99.0)(webpack@5.106.2(postcss@8.4.35)))(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.4.1)
       '@vue/cli-shared-utils': 5.0.9
       eslint: 9.39.4
       eslint-webpack-plugin: 3.2.0(eslint@9.39.4)(webpack@5.106.2(postcss@8.4.35))
@@ -7874,19 +7878,19 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@vue/cli-plugin-router@5.0.9(@vue/cli-service@5.0.9(@babel/core@7.15.8)(lodash@4.18.1)(prettier@3.8.3)(sass-loader@12.6.0(sass@1.99.0)(webpack@5.106.2(postcss@8.4.35)))(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.4.1))':
+  '@vue/cli-plugin-router@5.0.9(@vue/cli-service@5.0.9(@babel/core@7.15.8)(lodash@4.18.1)(prettier@3.8.3)(sass-loader@16.0.8(sass@1.99.0)(webpack@5.106.2(postcss@8.4.35)))(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.4.1))':
     dependencies:
-      '@vue/cli-service': 5.0.9(@babel/core@7.15.8)(lodash@4.18.1)(prettier@3.8.3)(sass-loader@12.6.0(sass@1.99.0)(webpack@5.106.2(postcss@8.4.35)))(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.4.1)
+      '@vue/cli-service': 5.0.9(@babel/core@7.15.8)(lodash@4.18.1)(prettier@3.8.3)(sass-loader@16.0.8(sass@1.99.0)(webpack@5.106.2(postcss@8.4.35)))(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.4.1)
       '@vue/cli-shared-utils': 5.0.9
     transitivePeerDependencies:
       - encoding
 
-  '@vue/cli-plugin-unit-jest@5.0.9(@vue/cli-service@5.0.9(@babel/core@7.15.8)(lodash@4.18.1)(prettier@3.8.3)(sass-loader@12.6.0(sass@1.99.0)(webpack@5.106.2(postcss@8.4.35)))(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.4.1))(jest@24.9.0)':
+  '@vue/cli-plugin-unit-jest@5.0.9(@vue/cli-service@5.0.9(@babel/core@7.15.8)(lodash@4.18.1)(prettier@3.8.3)(sass-loader@16.0.8(sass@1.99.0)(webpack@5.106.2(postcss@8.4.35)))(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.4.1))(jest@24.9.0)':
     dependencies:
       '@babel/core': 7.15.8
       '@babel/plugin-transform-modules-commonjs': 7.19.6(@babel/core@7.15.8)
       '@types/jest': 27.5.2
-      '@vue/cli-service': 5.0.9(@babel/core@7.15.8)(lodash@4.18.1)(prettier@3.8.3)(sass-loader@12.6.0(sass@1.99.0)(webpack@5.106.2(postcss@8.4.35)))(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.4.1)
+      '@vue/cli-service': 5.0.9(@babel/core@7.15.8)(lodash@4.18.1)(prettier@3.8.3)(sass-loader@16.0.8(sass@1.99.0)(webpack@5.106.2(postcss@8.4.35)))(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.4.1)
       '@vue/cli-shared-utils': 5.0.9
       babel-jest: 27.5.1(@babel/core@7.15.8)
       deepmerge: 4.2.2
@@ -7898,19 +7902,19 @@ snapshots:
       - encoding
       - supports-color
 
-  '@vue/cli-plugin-vuex@5.0.9(@vue/cli-service@5.0.9(@babel/core@7.15.8)(lodash@4.18.1)(prettier@3.8.3)(sass-loader@12.6.0(sass@1.99.0)(webpack@5.106.2(postcss@8.4.35)))(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.4.1))':
+  '@vue/cli-plugin-vuex@5.0.9(@vue/cli-service@5.0.9(@babel/core@7.15.8)(lodash@4.18.1)(prettier@3.8.3)(sass-loader@16.0.8(sass@1.99.0)(webpack@5.106.2(postcss@8.4.35)))(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.4.1))':
     dependencies:
-      '@vue/cli-service': 5.0.9(@babel/core@7.15.8)(lodash@4.18.1)(prettier@3.8.3)(sass-loader@12.6.0(sass@1.99.0)(webpack@5.106.2(postcss@8.4.35)))(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.4.1)
+      '@vue/cli-service': 5.0.9(@babel/core@7.15.8)(lodash@4.18.1)(prettier@3.8.3)(sass-loader@16.0.8(sass@1.99.0)(webpack@5.106.2(postcss@8.4.35)))(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.4.1)
 
-  '@vue/cli-service@5.0.9(@babel/core@7.15.8)(lodash@4.18.1)(prettier@3.8.3)(sass-loader@12.6.0(sass@1.99.0)(webpack@5.106.2(postcss@8.4.35)))(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.4.1)':
+  '@vue/cli-service@5.0.9(@babel/core@7.15.8)(lodash@4.18.1)(prettier@3.8.3)(sass-loader@16.0.8(sass@1.99.0)(webpack@5.106.2(postcss@8.4.35)))(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.4.1)':
     dependencies:
       '@babel/helper-compilation-targets': 7.20.0(@babel/core@7.15.8)
       '@soda/friendly-errors-webpack-plugin': 1.8.1(webpack@5.106.2(postcss@8.4.35))
       '@soda/get-current-script': 1.0.2
       '@types/minimist': 1.2.2
       '@vue/cli-overlay': 5.0.9
-      '@vue/cli-plugin-router': 5.0.9(@vue/cli-service@5.0.9(@babel/core@7.15.8)(lodash@4.18.1)(prettier@3.8.3)(sass-loader@12.6.0(sass@1.99.0)(webpack@5.106.2(postcss@8.4.35)))(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.4.1))
-      '@vue/cli-plugin-vuex': 5.0.9(@vue/cli-service@5.0.9(@babel/core@7.15.8)(lodash@4.18.1)(prettier@3.8.3)(sass-loader@12.6.0(sass@1.99.0)(webpack@5.106.2(postcss@8.4.35)))(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.4.1))
+      '@vue/cli-plugin-router': 5.0.9(@vue/cli-service@5.0.9(@babel/core@7.15.8)(lodash@4.18.1)(prettier@3.8.3)(sass-loader@16.0.8(sass@1.99.0)(webpack@5.106.2(postcss@8.4.35)))(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.4.1))
+      '@vue/cli-plugin-vuex': 5.0.9(@vue/cli-service@5.0.9(@babel/core@7.15.8)(lodash@4.18.1)(prettier@3.8.3)(sass-loader@16.0.8(sass@1.99.0)(webpack@5.106.2(postcss@8.4.35)))(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.4.1))
       '@vue/cli-shared-utils': 5.0.9
       '@vue/component-compiler-utils': 3.3.0(lodash@4.18.1)
       '@vue/vue-loader-v15': vue-loader@15.11.1(css-loader@6.11.0(webpack@5.106.2(postcss@8.4.35)))(lodash@4.18.1)(prettier@3.8.3)(vue-template-compiler@2.7.16)(webpack@5.106.2(postcss@8.4.35))
@@ -7960,7 +7964,7 @@ snapshots:
       webpack-virtual-modules: 0.4.6
       whatwg-fetch: 3.6.20
     optionalDependencies:
-      sass-loader: 12.6.0(sass@1.99.0)(webpack@5.106.2(postcss@8.4.35))
+      sass-loader: 16.0.8(sass@1.99.0)(webpack@5.106.2(postcss@8.4.35))
       vue-template-compiler: 2.7.16
       webpack-sources: 3.4.1
     transitivePeerDependencies:
@@ -12371,13 +12375,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  sass-loader@12.6.0(sass@1.99.0)(webpack@5.106.2(postcss@8.4.35)):
+  sass-loader@16.0.8(sass@1.99.0)(webpack@5.106.2(postcss@8.4.35)):
     dependencies:
-      klona: 2.0.5
       neo-async: 2.6.2
-      webpack: 5.106.2(cssnano@5.1.15(postcss@8.4.35))(postcss@8.4.35)
     optionalDependencies:
       sass: 1.99.0
+      webpack: 5.106.2(cssnano@5.1.15(postcss@8.4.35))(postcss@8.4.35)
 
   sass@1.99.0:
     dependencies:

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -287,6 +287,6 @@ export default {
 </script>
 
 <style lang="scss">
-@import './src/styles/tiptap/variables';
-@import './src/styles/tiptap/menububble';
+@import '../styles/tiptap/variables';
+@import '../styles/tiptap/menububble';
 </style>

--- a/vue.config.js
+++ b/vue.config.js
@@ -5,4 +5,13 @@ module.exports = {
     publicPath: process.env.NODE_ENV === 'production' ? '/admin/' : '/',
     runtimeCompiler: true,
     lintOnSave: false,
+    css: {
+        loaderOptions: {
+            sass: {
+                sassOptions: {
+                    quietDeps: true,
+                },
+            },
+        },
+    },
 };


### PR DESCRIPTION
## Summary

- Bump `sass-loader` ^12.6.0 → ^16.0.8
- Fix `Editor.vue` SCSS `@import` paths: `./src/styles/...` → `../styles/...` — sass-loader 14+ resolves paths relative to the component file rather than the project root
- Add `quietDeps: true` to `vue.config.js` to silence deprecation warnings originating from Bootstrap 4's SCSS in `node_modules` (legacy `@import`, color functions)

## Test plan

- [ ] `pnpm build` completes without errors
- [ ] `pnpm lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)